### PR TITLE
Allow disabling change of bullet style on level change

### DIFF
--- a/doc/bullets.txt
+++ b/doc/bullets.txt
@@ -223,6 +223,15 @@ You can always manually renumber the current list or visual selection using
 `gN` in NORMAL or VISUAL mode.
 
 
+Change Bullet style on Level Change
+-----------------------------------
+By default, when promoting/demoting a bullet its bullet point is changed to
+the next style defined in g:bullets_outline_level.  This can be disabled by
+setting the following:
+
+  `let g:bullets_change_style_on_level_change = 0`
+
+
 Toggle Parent and Child Checkboxes
 ----------------------------------
 If a checkbox has child checkboxes, checking the checkbox will check all

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -67,6 +67,10 @@ if !exists('g:bullets_renumber_on_change')
   let g:bullets_renumber_on_change = 1
 endif
 
+if !exists('g:bullets_change_style_on_level_change')
+  let g:bullets_change_style_on_level_change = 1
+endif
+
 if !exists('g:bullets_nested_checkboxes')
   " Enable nested checkboxes that toggle parents and children when the current
   " checkbox status changes
@@ -831,6 +835,10 @@ fun! s:change_bullet_level(direction)
 
   if l:curr_line == []
     " If the current line is not a bullet then don't do anything else.
+    return
+  endif
+
+  if !g:bullets_change_style_on_level_change
     return
   endif
 


### PR DESCRIPTION
This commit introduces a new option `g:bullets_change_style_on_level_change`
to allow disabling the automatic change of bullet style when
promoting/demoting bullet items.