### PR TITLE
Bugfix - strcharlen support older vim

### DIFF
--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -586,11 +586,11 @@ command! InsertNewBullet call <SID>insert_new_bullet()
 "   returns 1 if current line ends in a colon, else 0
 fun! s:line_ends_in_colon(lnum)
   let l:line = getline(a:lnum)
-  # Older versions of vim do not support strchar*
   if exists("*strcharlen") && exists("*strcharget")
     let l:last_char_nr = strgetchar(l:line, strcharlen(l:line)-1)
     return l:last_char_nr == 65306 || l:last_char_nr == 58
   else
+    " Older versions of vim do not support strchar*
     return l:line[strlen(l:line)-1:] ==# ':'
   endif
 endfun

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -585,8 +585,14 @@ command! InsertNewBullet call <SID>insert_new_bullet()
 " Helper for Colon Indent
 "   returns 1 if current line ends in a colon, else 0
 fun! s:line_ends_in_colon(lnum)
-  let l:last_char_nr = strgetchar(getline(a:lnum), strcharlen(getline(a:lnum))-1)
-  return l:last_char_nr == 65306 || l:last_char_nr == 58
+  let l:line = getline(a:lnum)
+  # Older versions of vim do not support strchar*
+  if exists("*strcharlen") && exists("*strcharget")
+    let l:last_char_nr = strgetchar(l:line, strcharlen(l:line)-1)
+    return l:last_char_nr == 65306 || l:last_char_nr == 58
+  else
+    return l:line[strlen(l:line)-1:] ==# ':'
+  endif
 endfun
 " --------------------------------------------------------- }}}
 

--- a/plugin/bullets.vim
+++ b/plugin/bullets.vim
@@ -586,7 +586,7 @@ command! InsertNewBullet call <SID>insert_new_bullet()
 "   returns 1 if current line ends in a colon, else 0
 fun! s:line_ends_in_colon(lnum)
   let l:line = getline(a:lnum)
-  if exists("*strcharlen") && exists("*strcharget")
+  if exists("*strcharlen") && exists("*strgetchar")
     let l:last_char_nr = strgetchar(l:line, strcharlen(l:line)-1)
     return l:last_char_nr == 65306 || l:last_char_nr == 58
   else


### PR DESCRIPTION
We appear to have introduced a bug in #148 where we use functions not available in old vim versions.

Adding fallback logic to solve this. Addressed #149 